### PR TITLE
fixed "ComponentWorker" not declared.

### DIFF
--- a/addons/componentable/componentable.gd
+++ b/addons/componentable/componentable.gd
@@ -6,8 +6,10 @@ var componentable_ui: Control
 func _enter_tree():
 	componentable_ui = preload("res://addons/componentable/editor/componentable_inspector.tscn").instantiate()
 	add_autoload_singleton("Component", "res://addons/componentable/Component.gd")
+	add_autoload_singleton("ComponentWorker", "res://addons/componentable/workers/component_worker.gd")
 	add_control_to_dock(DockSlot.DOCK_SLOT_RIGHT_UL, componentable_ui)
 
 func _exit_tree():
 	remove_control_from_docks(componentable_ui)
+	remove_autoload_singleton("ComponentWorker")
 	remove_autoload_singleton("Component")


### PR DESCRIPTION
This error occurs in Godot v4.4.1. Adding a singleton for "ComponentWorker" fixed the issue.
#8 